### PR TITLE
ARCSPC-828 search button display bug in intermediary width

### DIFF
--- a/public/assets/harvard.css
+++ b/public/assets/harvard.css
@@ -388,6 +388,8 @@ h1 > span.title {
     margin: auto;
   }
   .search-keyword.repeats.form-control {
+    /* JQuery is checking for this border-radius property in lieu of window width to keep media queries and jquery $(window).width() in alignment
+    If changed it must be updated in harvard.js's responsive search method */
     border-radius: 0 4px 4px 0;
     min-width: 6.1rem;
   }

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -181,21 +181,25 @@ function responsive_search(){
     $("#mobile-submit").append($search_button);
   }
   // listen for browser size change and move button accordingly
-  $(window).resize(function(){
-    if($(window).width() < 768){
+  $(window).resize(function(){  
+    // This is listening to a property in harvard.css that toggles at 767px using css media queries.
+    // JQuery's $(window).width() was out of alignment with it on some devices, so we're explicitly tying the two together
+    if($(".search-keyword.repeats.form-control").css("border-radius") === "0px 4px 4px 0px"){
       if($('#mobile-submit').find($search_button).length)
       {
         // do nothing
       }
       else {
+        console.log('okfoakfj')
         $("#mobile-submit").append($search_button);
       }
     }
-    if($(window).width() > 767){
+    if($(".search-keyword.repeats.form-control").css("border-radius") === "0px"){
       if($('#search_row_0').find('.input-group-btn').find($search_button).length){
         // do nothing
       }
       else {
+        console.log('okfoakfj')
         $('#search_row_0').find('.input-group-btn').append($search_button);
       }
     }

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -184,7 +184,8 @@ function responsive_search(){
   $(window).resize(function(){  
     // This is listening to a property in harvard.css that toggles at 767px using css media queries.
     // JQuery's $(window).width() was out of alignment with it on some devices, so we're explicitly tying the two together
-    if($(".search-keyword.repeats.form-control").css("border-radius") === "0px 4px 4px 0px"){
+    // We use borderTopRightRadius because Firefox doesn't like jQuery looking at border-radius
+    if($(".search-keyword.repeats.form-control").css("borderTopRightRadius") === "4px"){
       if($('#mobile-submit').find($search_button).length)
       {
         // do nothing
@@ -194,7 +195,7 @@ function responsive_search(){
         $("#mobile-submit").append($search_button);
       }
     }
-    if($(".search-keyword.repeats.form-control").css("border-radius") === "0px"){
+    if($(".search-keyword.repeats.form-control").css("borderTopRightRadius") === "0px"){
       if($('#search_row_0').find('.input-group-btn').find($search_button).length){
         // do nothing
       }

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -191,7 +191,6 @@ function responsive_search(){
         // do nothing
       }
       else {
-        console.log('okfoakfj')
         $("#mobile-submit").append($search_button);
       }
     }
@@ -200,7 +199,6 @@ function responsive_search(){
         // do nothing
       }
       else {
-        console.log('okfoakfj')
         $('#search_row_0').find('.input-group-btn').append($search_button);
       }
     }


### PR DESCRIPTION
ARCSPC-882
https://jira.huit.harvard.edu/browse/ARCSPC-882

This fix seems to work on Michael's pc but may require more testing. The error was caused by jquery and css media queries calculating width differently, and causing one to hit a breakpoint before another despite checking for the exact same value. It only happened on some devices (was ok on mac, broke on pc).

Resolved by having jquery watch for a css media query toggled property instead of looking directly at window width.