### PR TITLE
Arcspc 925 search form caret missing from dropdown

### DIFF
--- a/public/assets/harvard.css
+++ b/public/assets/harvard.css
@@ -402,7 +402,7 @@ h1 > span.title {
     /* JQuery is checking for this border-radius property in lieu of window width to keep media queries and jquery $(window).width() in alignment
     If changed it must be updated in harvard.js's responsive search method */
     border-radius: 0 4px 4px 0;
-    min-width: 6.1rem;
+    min-width: 6.4rem;
   }
 
   #submit_search.inline-search-btn {
@@ -540,7 +540,7 @@ div.search {
     width:100px !important;
   }
   .limit-filter-col {
-    min-width: 250px;
+    min-width: 290px;
   }
 }
 

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -173,10 +173,14 @@ function responsive_search(){
     var observer = new MutationObserver(function(mutations) {
       // For the sake of...observation...let's output the mutation to console to see how this all works
       mutations.forEach(function(mutation) {
+        let $down_caret = $("#down-caret")
         $new_keyword = $(mutation.addedNodes[0]).find($('select[id^="field"]')).children().first();
+        $new_limit = $(mutation.addedNodes[0]).find($('.limit-field')).children().first();
         // I don't know why I can't do this on one line but it breaks the plusminus fcnality when I do so.
-        $new_down_caret = $down_caret.clone();
-        $new_down_caret.appendTo($new_keyword);
+        $new_keyword_down_caret = $down_caret.clone();
+        $new_limit_down_caret = $down_caret.clone();
+        $new_keyword_down_caret.appendTo($new_keyword);
+        $new_limit_down_caret.appendTo($new_limit)
       });
     });
 
@@ -227,6 +231,51 @@ function responsive_search(){
   });
 }
 
+function handleDropdownCarets(event) {
+  // get all children of the changed dropdown
+  let $targetDropdownOptions = $(event.target).children()
+  $targetDropdownOptions.each(function() {
+    if ($(this)[0].selected) {
+      // If the option is selected, we add a down-caret to the end
+      let $down_caret = $("#down-caret")
+      let $new_down_caret = $down_caret.clone();
+      $new_down_caret.appendTo($(this));
+    } else {
+      // If the option is not selected, we make sure there is no down-caret on it
+      if ($(this).find("span").length > 0) {
+        $(this).find("span").remove();
+      }
+    }
+  })
+
+
+
+  // var keyword, down_caret, limit, limit_down_caret;	
+  // keyword = $("select.search-keyword").children("option:selected")
+  // if (keyword == null) {
+	//   keyword = $("select.search-keyword").children().first();
+  // }
+  // down_caret = $("#down-caret");
+  // down_caret.appendTo(keyword);
+  // $("select.search-keyword").change(function(){
+	//   $("select.search-keyword").children().remove(down_caret)
+	//   keyword = $("select.search-keyword").children("option:selected");
+	//   down_caret.appendTo(keyword);
+  // });
+  
+  // limit = $("select.limit-field").children("option:selected")
+  // if (limit == null) {
+	//   limit = $("select.limit-field").children().first();
+  // }
+  // limit_down_caret = down_caret.clone();
+  // limit_down_caret.appendTo(limit);
+  // $("select.limit-field").change(function(){
+	//   $("select.limit-field").children().remove(limit_down_caret)
+	//   limit = $("select.limit-field").children("option:selected");
+	//   limit_down_caret.appendTo(limit);
+  // });
+}
+
 // Keyboard controls for bootstrap dropdown menus
 function toggleDropdown(event) {
   let currentElement = $(event.currentTarget);
@@ -257,6 +306,7 @@ function toggleMoreFacets(event) {
   }
 }
 
+// Add listeners
 $(window).on('load', function() {
   $("body").on('keydown', '.dropdown-toggle, .dropdown > .dropdown-menu > li > a', function(event) {
     toggleDropdown(event)
@@ -264,5 +314,9 @@ $(window).on('load', function() {
 
   $("body").on('keydown', '.more.btn.refine, .less.btn.refine', function(event) {
     toggleMoreFacets(event)
+  })
+
+  $("body").on('change', 'select.search-keyword, select.limit-field', function(event) {
+    handleDropdownCarets(event)
   })
 })

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -1,5 +1,5 @@
 // create a down caret that we can use throughout for dropdown menus
-let $downCaret = '<span class="float-right search-down-caret hidden">&nbsp&nbsp&nbsp&#9662</span>'
+let $downCaret = '<span class="float-right search-down-caret hidden">&nbsp&nbsp&#9662</span>'
 
 function HarvardSidebar($sidebar) {
     this.$sidebar = $sidebar;
@@ -171,8 +171,6 @@ function responsive_search(){
         $($downCaret).appendTo($new_keyword);
         $($downCaret).appendTo($new_limit)
       });
-
-      // making additional limit fields invisible and uninteractable instead of removing them to keep consistent formatting
     });
 
     // Notify me of everything!

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -150,28 +150,19 @@ function responsive_search(){
   }
   down_caret = $("#down-caret");
   down_caret.appendTo(keyword);
-  $("select.search-keyword").change(function(){
-	  $("select.search-keyword").children().remove(down_caret)
-	  keyword = $("select.search-keyword").children("option:selected");
-	  down_caret.appendTo(keyword);
-  });
-  
+
   limit = $("select.limit-field").children("option:selected")
   if (limit == null) {
 	  limit = $("select.limit-field").children().first();
   }
   limit_down_caret = down_caret.clone();
   limit_down_caret.appendTo(limit);
-  $("select.limit-field").change(function(){
-	  $("select.limit-field").children().remove(limit_down_caret)
-	  limit = $("select.limit-field").children("option:selected");
-	  limit_down_caret.appendTo(limit);
-  });
 	
 //Not sure what this code actually does so I'm not touching it
   $(document).ready(function(){
     var observer = new MutationObserver(function(mutations) {
       // For the sake of...observation...let's output the mutation to console to see how this all works
+      
       mutations.forEach(function(mutation) {
         let $down_caret = $("#down-caret")
         $new_keyword = $(mutation.addedNodes[0]).find($('select[id^="field"]')).children().first();
@@ -182,6 +173,10 @@ function responsive_search(){
         $new_keyword_down_caret.appendTo($new_keyword);
         $new_limit_down_caret.appendTo($new_limit)
       });
+
+      // making additional limit fields invisible and uninteractable instead of removing them to keep consistent formatting
+      $(".form-group.limit-filter-col:not(:first)").css("visibility", "hidden")
+      $(".limit-field:not(:first)").prop("disabled", "true")
     });
 
     // Notify me of everything!
@@ -247,33 +242,6 @@ function handleDropdownCarets(event) {
       }
     }
   })
-
-
-
-  // var keyword, down_caret, limit, limit_down_caret;	
-  // keyword = $("select.search-keyword").children("option:selected")
-  // if (keyword == null) {
-	//   keyword = $("select.search-keyword").children().first();
-  // }
-  // down_caret = $("#down-caret");
-  // down_caret.appendTo(keyword);
-  // $("select.search-keyword").change(function(){
-	//   $("select.search-keyword").children().remove(down_caret)
-	//   keyword = $("select.search-keyword").children("option:selected");
-	//   down_caret.appendTo(keyword);
-  // });
-  
-  // limit = $("select.limit-field").children("option:selected")
-  // if (limit == null) {
-	//   limit = $("select.limit-field").children().first();
-  // }
-  // limit_down_caret = down_caret.clone();
-  // limit_down_caret.appendTo(limit);
-  // $("select.limit-field").change(function(){
-	//   $("select.limit-field").children().remove(limit_down_caret)
-	//   limit = $("select.limit-field").children("option:selected");
-	//   limit_down_caret.appendTo(limit);
-  // });
 }
 
 // Keyboard controls for bootstrap dropdown menus

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -1,3 +1,6 @@
+// create a down caret that we can use throughout for dropdown menus
+let $downCaret = '<span class="float-right search-down-caret hidden">&nbsp&nbsp&nbsp&#9662</span>'
+
 function HarvardSidebar($sidebar) {
     this.$sidebar = $sidebar;
     this.$row = $sidebar.closest('.row');
@@ -143,20 +146,18 @@ $(function() {
   }
 });
 function responsive_search(){
-  var keyword, down_caret, limit, limit_down_caret;	
+  var keyword, limit;	
   keyword = $("select.search-keyword").children("option:selected")
   if (keyword == null) {
 	  keyword = $("select.search-keyword").children().first();
   }
-  down_caret = $("#down-caret");
-  down_caret.appendTo(keyword);
+  $($downCaret).appendTo(keyword);
 
   limit = $("select.limit-field").children("option:selected")
   if (limit == null) {
 	  limit = $("select.limit-field").children().first();
   }
-  limit_down_caret = down_caret.clone();
-  limit_down_caret.appendTo(limit);
+  $($downCaret).appendTo(limit);
 	
 //Not sure what this code actually does so I'm not touching it
   $(document).ready(function(){
@@ -164,14 +165,11 @@ function responsive_search(){
       // For the sake of...observation...let's output the mutation to console to see how this all works
       
       mutations.forEach(function(mutation) {
-        let $down_caret = $("#down-caret")
         $new_keyword = $(mutation.addedNodes[0]).find($('select[id^="field"]')).children().first();
         $new_limit = $(mutation.addedNodes[0]).find($('.limit-field')).children().first();
         // I don't know why I can't do this on one line but it breaks the plusminus fcnality when I do so.
-        $new_keyword_down_caret = $down_caret.clone();
-        $new_limit_down_caret = $down_caret.clone();
-        $new_keyword_down_caret.appendTo($new_keyword);
-        $new_limit_down_caret.appendTo($new_limit)
+        $($downCaret).appendTo($new_keyword);
+        $($downCaret).appendTo($new_limit)
       });
 
       // making additional limit fields invisible and uninteractable instead of removing them to keep consistent formatting
@@ -232,13 +230,11 @@ function handleDropdownCarets(event) {
   $targetDropdownOptions.each(function() {
     if ($(this)[0].selected) {
       // If the option is selected, we add a down-caret to the end
-      let $down_caret = $("#down-caret")
-      let $new_down_caret = $down_caret.clone();
-      $new_down_caret.appendTo($(this));
+      $($downCaret).appendTo($(this));
     } else {
       // If the option is not selected, we make sure there is no down-caret on it
-      if ($(this).find("span").length > 0) {
-        $(this).find("span").remove();
+      if ($(this).find("span.search-down-caret").length > 0) {
+        $(this).find("span.search-down-caret").remove();
       }
     }
   })

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -173,8 +173,6 @@ function responsive_search(){
       });
 
       // making additional limit fields invisible and uninteractable instead of removing them to keep consistent formatting
-      $(".form-group.limit-filter-col:not(:first)").css("visibility", "hidden")
-      $(".limit-field:not(:first)").prop("disabled", "true")
     });
 
     // Notify me of everything!

--- a/public/views/shared/_search.html.erb
+++ b/public/views/shared/_search.html.erb
@@ -4,7 +4,6 @@
   <% @search = Search.new unless defined?(@search) %>
   <%= form_tag(app_prefix("#{search_url}"), method: 'get', :id => 'advanced_search') do %>
   <% (0...[1, @search.q.length].max).each do |i| %>
-  <span id="down-caret" class="float-right search-down-caret hidden"><%= "   " + 9662.chr(Encoding::UTF_8) %></span>
   <div class="row search_row col-md-10" id="search_row_<%= i %>">
     <div class="search_row_container form-inline">
 

--- a/public/views/shared/_search.html.erb
+++ b/public/views/shared/_search.html.erb
@@ -24,14 +24,14 @@
       </div>
     </div>
     <div class="search-filter-row form-inline">
-      <% if i == 0 %>
         <div class="form-group limit-filter-col norepeat">
-          <%= label_tag(:limit, t('search-limit'),:class => 'sr-only') %>
-          <span class="inline-label repeats"><%= t('search-limit') %>:</span>
-          <%= select_tag(:limit, options_for_select(limit_options, @search[:limit]), :class=> 'form-control search_placeholder limit-field') %>
+          <% if i == 0 %>
+            <%= label_tag(:limit, t('search-limit'),:class => 'sr-only') %>
+            <span class="inline-label repeats"><%= t('search-limit') %>:</span>
+            <%= select_tag(:limit, options_for_select(limit_options, @search[:limit]), :class=> 'form-control search_placeholder limit-field') %>
+          <% end %>
         </div>
-      <% end %>
-       <div class="<%= (i > 0)? 'col-sm-offset-4 ' : '' %> form-group years-filter-col search_placeholder">
+       <div class="form-group years-filter-col search_placeholder">
         <span class="inline-label repeats"><%= t('search_results.filter.years') %>:</span>
         <%= label_tag(:"from_year#{i}", "#{t('search_results.filter.from_year')}", :class => 'sr-only repeats') %>
         <%= text_field_tag('from_year[]', @search[:from_year][i], :size => 4,:maxlength => 4, :id=>"from_year#{i}",

--- a/public/views/shared/_search.html.erb
+++ b/public/views/shared/_search.html.erb
@@ -25,7 +25,7 @@
     </div>
     <div class="search-filter-row form-inline">
       <% if i == 0 %>
-        <div class="form-group limit-filter-col">
+        <div class="form-group limit-filter-col norepeat">
           <%= label_tag(:limit, t('search-limit'),:class => 'sr-only') %>
           <span class="inline-label repeats"><%= t('search-limit') %>:</span>
           <%= select_tag(:limit, options_for_select(limit_options, @search[:limit]), :class=> 'form-control search_placeholder limit-field') %>


### PR DESCRIPTION
This PR contains fixes for the missing caret, and the other subtasks that I added to that ticket in Jira:

Missing Carets - https://jira.huit.harvard.edu/browse/ARCSPC-925
Multiple Carets - https://jira.huit.harvard.edu/browse/ARCSPC-950
Broken Plus/Minus Buttons - https://jira.huit.harvard.edu/browse/ARCSPC-949
Duplicate Limit Fields (should only ever be one) - https://jira.huit.harvard.edu/browse/ARCSPC-951