### PR TITLE
New branch to avoid tangled git mess on the previous one

### DIFF
--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -312,7 +312,7 @@ Rails.application.config.after_initialize do
       aleph_id = ''
       alma_id = ''
       unless result.notes['processinfo'].blank?
-        notes = result.notes['processinfo']
+        notes = result.notes['processinfo'][0]
         label = notes.dig('label') || ''
         if label == 'Aleph ID'
           aleph_id = notes['note_text']

--- a/public/views/resources/_resource_tab.erb
+++ b/public/views/resources/_resource_tab.erb
@@ -1,8 +1,17 @@
 <% active = (action.to_s == controller.action_name) %>
 <% unless hidden && !active %>
   <div class='col-sm-4 nav-pill <% if active %>active <% elsif !enabled %> disabled<% end %>'>
+  <% case action
+  		 when :show
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}")
+  		 when :infinite
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/collection_organization")
+  		 when :inventory
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/inventory")
+  		 end
+  	%>
     <%=
-      link_to_unless active || !enabled, text, { :action => action } do
+      link_to_unless active || !enabled, text, url  do
         link_to_if active, text, '#', :class => "active" do
           link_to text, "#"
         end

--- a/public/views/shared/_facets.html.erb
+++ b/public/views/shared/_facets.html.erb
@@ -20,10 +20,12 @@
         </span></li>
       </ul>
   <% end  %>
-   <% @filters.each do |k,h|  %>
-    <li class="list-group-item"><span class="filter"><%= h['pt'] %>: <%= h['pv'] %>
-    <a href="<%= app_prefix(h['uri'])%>"
-      title="<%= t('search_results.remove_filter') %> " class="delete_filter">X</a></li>
+  <% @filters.each do |k, a| %>
+    <% a.each do |h| %>
+     <li class="list-group-item"><span class="filter"><%= h['pt'] %>: <%= h['pv'] %>
+     <a href="<%= app_prefix(h['uri'])%>"
+       title="<%= t('search_results.remove_filter') %> " class="delete_filter">X</a></li>
+    <% end %>
    <% end %>
  <% end %>
 </div>

--- a/public/views/shared/_print_page_action.html.erb
+++ b/public/views/shared/_print_page_action.html.erb
@@ -1,5 +1,5 @@
 <% if AppConfig[:pui_max_concurrent_pdfs] > 0 %>
-    <%= form_tag(url_for(:controller => :hvd_pdf, :action => :fetch), method: 'get', :id => 'print_form') do %>
+<%= form_tag(app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/fetch_pdf"), method: 'get', :id => 'print_form') do %>
         <%= hidden_field_tag(:base_token, SecureRandom.hex) %>
         <%= hidden_field_tag(:token, "") %>
         <button id="print_button" class="btn btn-default page_action print">


### PR DESCRIPTION
The previous branch for the bug fix when moving the PUI to a 2.7 version of ArchivesSpace got lost in a tangled git mess, so here's a new one with all of the changes that merges correctly. Deedee's original comments:

"When attempting to view a resource in the PUI, the request was failing and receiving a Rails error. This error was not present in 2.5.2 but appeared when using our PUI in 2.7.

One of the problems was that the notes fields being pulled back through JSON were originally returned as a has but in 2.7 they are returned as an array of hashes. This was corrected in our PUI by selecting the first index of the array. This corrected the expected hash issue and was tested against the expected results and found no discrepancies.

The second problem was that several places in our PUI code we use form helpers to generate links. ASpace master changed its solution in 2.6 to use hard coded urls with variable values. Changing ours to match the ASpace version corrected this problem."

This branch is NOT to be merged until we no longer need to support ASpace version 2.5. Releases are to be tagged as twoseven_v2.3.12 (or whatever number is appropriate)

