### PR TITLE
ARCSPC-942: Bug fix for focus indicators not functioning in Firefox

### DIFF
--- a/public/assets/harvard-sidebar-expandbuttons.js
+++ b/public/assets/harvard-sidebar-expandbuttons.js
@@ -20,14 +20,13 @@ $(function () {
     var addExpandActions = function () {
         var $eadBtn = $("button.expandme");
         if ($eadBtn.length > 0) {
-        $("button.expandme").focusin(function() {
-            $(this).find("i").addClass("focusIcon")
-        })
-        
-        $("button.expandme").focusout(function() {
-            $(this).find("i").removeClass("focusIcon")
-        })
-        // expandActionsAdded = true;
+            $("button.expandme").focusin(function() {
+                $(this).find("i").addClass("focusIcon")
+            })
+            
+            $("button.expandme").focusout(function() {
+                $(this).find("i").removeClass("focusIcon")
+            })
         }
     };
     

--- a/public/assets/harvard-sidebar-expandbuttons.js
+++ b/public/assets/harvard-sidebar-expandbuttons.js
@@ -1,0 +1,36 @@
+// This Javascript file is for the purpose of ensuring that the expand arrows in the sidebar
+// are able to receive the correct actions. Because of the order core ASpace loads the content
+// we have to do this in a roundabout way
+
+$(function () {
+    /* Per Bobbi Fox regarding a solution to a similar situation in the aspace-ead-xform plugin:
+    this defer methodolgy is adapted from
+    https://stackoverflow.com/questions/7486309/how-to-make-script-execution-wait-until-jquery-is-loaded
+    since the sidebar content loads *after* the javascript is loaded, we need to to this */
+
+    function defer(method) {
+        if ($("button.expandme").length > 0) {
+            method();
+        }
+        else {
+            setTimeout(function() { defer(method) }, 50);
+        }
+    }
+    
+    var addExpandActions = function () {
+        var $eadBtn = $("button.expandme");
+        if ($eadBtn.length > 0) {
+        $("button.expandme").focusin(function() {
+            $(this).find("i").addClass("focusIcon")
+        })
+        
+        $("button.expandme").focusout(function() {
+            $(this).find("i").removeClass("focusIcon")
+        })
+        // expandActionsAdded = true;
+        }
+    };
+    
+    defer(addExpandActions);
+        
+});

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -275,5 +275,17 @@ $(window).on('load', function() {
   $("body").on('keydown', '.more.btn.refine, .less.btn.refine', function(event) {
     toggleMoreFacets(event)
   })
+
+  $("body").on('change', 'select.search-keyword, select.limit-field', function(event) {
+    handleDropdownCarets(event)
+  })
+
+  // Copy the number of requests from the menu option to the top "REQUEST" level. Intended behavior
+  // is leaving it in both places, so no need to remove
+  let requestNumber = $("#request_list_menu_item").text().match(/ \(\d+\)/)
+  if (requestNumber) {
+    let currentRequestMenuText = $("#dropdownMenu2").find("span").text()
+    $("#dropdownMenu2").find("span").text(currentRequestMenuText + requestNumber[0])
+  }
 })
 

--- a/public/assets/harvard.js
+++ b/public/assets/harvard.js
@@ -275,16 +275,5 @@ $(window).on('load', function() {
   $("body").on('keydown', '.more.btn.refine, .less.btn.refine', function(event) {
     toggleMoreFacets(event)
   })
-
-  $("button.expandme").focusin(function() {
-    $(this).find("i").addClass("focusIcon")
-  })
-
-  $("button.expandme").focusout(function() {
-    $(this).find("i").removeClass("focusIcon")
-  })
-
-  $("body").on('change', 'select.search-keyword, select.limit-field', function(event) {
-    handleDropdownCarets(event)
-  })
 })
+

--- a/public/assets/harvard_application.css
+++ b/public/assets/harvard_application.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
@@ -14006,8 +14007,10 @@ span.head {
 }
 .focusIcon {
   outline: 5px auto -webkit-focus-ring-color;
+  outline: 5px auto Highlight;
   outline-offset: -2px;
 }
+
 /* line 29, /home/aspaceadmbeta/archivesspace/public/vendor/assets/stylesheets/archivesspace/largetree.scss */
 .largetree-container .waypoint {
   height: 0;

--- a/public/views/objects/show.html.erb
+++ b/public/views/objects/show.html.erb
@@ -43,3 +43,4 @@
  <%= render partial: 'shared/modal_actions' %>
 </div>
 
+<%= javascript_include_tag "#{@base_url}/assets/harvard-sidebar-expandbuttons.js" %>

--- a/public/views/resources/digital_only.html.erb
+++ b/public/views/resources/digital_only.html.erb
@@ -34,3 +34,4 @@
 </div>
 
 <%= render partial: 'shared/modal_actions' %>
+<%= javascript_include_tag "#{@base_url}/assets/harvard-sidebar-expandbuttons.js" %>

--- a/public/views/resources/show.html.erb
+++ b/public/views/resources/show.html.erb
@@ -33,3 +33,4 @@
 </div>
 
 <%= render partial: 'shared/modal_actions' %>
+<%= javascript_include_tag "#{@base_url}/assets/harvard-sidebar-expandbuttons.js" %>


### PR DESCRIPTION
This bug stemmed from two issues, only one of which was Firefox dependent, and that was resolved by changing a change in the css. More pernicious was the expand buttons sometimes not receiving the actions that were being assigned with Javascript. This turned out to be because of the page loading order, and was resolved by creating a separate javascript file to embed on pages where the children_tree sidebar is used.