### PR TITLE
Fix for PUI CSV download bug

### DIFF
--- a/public/controllers/concerns/csv_support.rb
+++ b/public/controllers/concerns/csv_support.rb
@@ -55,10 +55,13 @@ module CsvSupport
      # get recs 20 at at time
      (1..(list.length-1)).step(20) do |start|
        stop = start + 19
+
        res = archivesspace.search_records(list.slice(start,20).compact, { 'page_size' => (stop - start + 1)})
-       res.records.each_index do |i|
-         result = res.records[i]
-#Rails.logger.debug(result.json.pretty_inspect) if i < 3 && start == 1
+       records = res.records
+       sorted_records = records.sort { |a, b| a.json['ref_id'] <=> b.json['ref_id'] }
+
+      sorted_records.each_index do |i|
+         result = sorted_records[i]
          if result.json['publish']
            level = ordered_recs[start + i]['depth']
            @levels[level] =  strip_mixed_content(result.json['title'])


### PR DESCRIPTION
**Fix for PUI CSV download bug**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ARCSPC-1038

Note: JIRA ticket contains example csvs of prod, broken behavior, and fixed behavior.

# What does this Pull Request do?
This pull request fixes the PUI CSV download bug that was introduced somewhere between aspace 2.5.2 and 2.8.1 in anticipation of upgrading to 3.0.2. 

# How should this be tested?
Download a CSV and compare with a CSV download of same resource on prod.