### PR TITLE
ARCSPC-1038: Fix for broken csv download

### DIFF
--- a/public/controllers/concerns/csv_support.rb
+++ b/public/controllers/concerns/csv_support.rb
@@ -55,7 +55,8 @@ module CsvSupport
      # get recs 20 at at time
      (1..(list.length-1)).step(20) do |start|
        stop = start + 19
-       res = archivesspace.search_records(list.slice(start,20).compact, { 'page_size' => (stop - start + 1)})
+
+       res = archivesspace.search_and_sort_records(list.slice(start,20).compact, { 'page_size' => (stop - start + 1)})
        res.records.each_index do |i|
          result = res.records[i]
 #Rails.logger.debug(result.json.pretty_inspect) if i < 3 && start == 1

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -78,6 +78,22 @@ Rails.application.config.after_initialize do
 #      Rails.application.routes.call(request_env)
       ActionController::Redirecting.redirect_to(path)
     end
+
+    # This method is intended to duplicate the functionality of search_records from aspace core, with the
+    # only difference being that the sort in core was updated to sort by 'uri' instead of 'id'
+    # This broke the order of our csv downloads. This new method has been created rather than overwriting
+    # the one in core to avoid unintended side effects
+    def search_and_sort_records(record_list, search_opts = {}, full_notes = false)
+      search_opts = DEFAULT_SEARCH_OPTS.merge(search_opts)
+
+      url = build_url('/search/records', search_opts.merge("uri[]" => record_list))
+      results = do_search(url)
+
+      # Ensure that the order of our results matches the order of `record_list`
+      results['results'] = results['results'].sort_by {|result| record_list.index(result.fetch('id'))}
+
+      SolrResults.new(results, search_opts, full_notes)
+    end
   end
 # override the citation construction
   class Resource


### PR DESCRIPTION
**Fix for broken CSV Download**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ARCSPC-1038

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Core archivesspace changed the sort method in search_records to 'uri', where it was previously 'id'. This broke the ordering of our csv downloads. A new method has been added that conducts the search and sort in the old way.

