### PR TITLE
Fix malformed catalogue link

### DIFF
--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -66,10 +66,10 @@ end %>
           <%= hollis_id %>
 	 <div class="sub-note">
 	 <span class="note-content"> <%= t('pdf_reports.perma') %></span>
-	   <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{hollis_id.gsub(/<p>|<\/p>/, '')}").html_safe %>
+	      <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{strip_tags hollis_id}").html_safe %>
 	 </div>
         <% else %>
-          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{hollis_id.gsub(/<p>|<\/p>/, '')}").html_safe %>
+          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{strip_tags hollis_id}").html_safe %>
         <% end %>
      <% end %>
 

--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -20,8 +20,6 @@ end %>
      hollis_id = note_struct['note_text']
    end
 
-   hollis_id.gsub!(/<p>|<\/p>/, '')
-   
    label_id = !which_id.blank? %>
 <%  if !note_struct['note_text'].blank? %>
     <div class="<%= type %> single_note" >
@@ -68,10 +66,10 @@ end %>
           <%= hollis_id %>
 	 <div class="sub-note">
 	 <span class="note-content"> <%= t('pdf_reports.perma') %></span>
-	   <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{hollis_id}").html_safe %>
+	   <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{hollis_id.gsub!(/<p>|<\/p>/, '')}").html_safe %>
 	 </div>
         <% else %>
-          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{hollis_id}").html_safe %>
+          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{hollis_id.gsub!(/<p>|<\/p>/, '')}").html_safe %>
         <% end %>
      <% end %>
 

--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -66,10 +66,10 @@ end %>
           <%= hollis_id %>
 	 <div class="sub-note">
 	 <span class="note-content"> <%= t('pdf_reports.perma') %></span>
-	   <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{hollis_id.gsub!(/<p>|<\/p>/, '')}").html_safe %>
+	   <%= t("pdf_reports.perma_link", :idpiece => "#{which_id}/#{hollis_id.gsub(/<p>|<\/p>/, '')}").html_safe %>
 	 </div>
         <% else %>
-          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{hollis_id.gsub!(/<p>|<\/p>/, '')}").html_safe %>
+          <%= t("enumerations.hollis_link", :idpiece => "#{which_id}/#{hollis_id.gsub(/<p>|<\/p>/, '')}").html_safe %>
         <% end %>
      <% end %>
 

--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -19,6 +19,9 @@ end %>
      which_id = 'alma'
      hollis_id = note_struct['note_text']
    end
+
+   hollis_id.gsub!(/<p>|<\/p>/, '')
+   
    label_id = !which_id.blank? %>
 <%  if !note_struct['note_text'].blank? %>
     <div class="<%= type %> single_note" >


### PR DESCRIPTION
This pr fixes malformed catalogue links by removing excess <p> tags. The tags made it into the link as a result of this pr in core:
https://github.com/archivesspace/archivesspace/commit/165695006315d3b802b48a582d3a7ba8ae760972 (note_renderer.rb, line 80)

Before the update, html tags were not added to a rendered note's text field due to the behavior of .join when used upon a single item array. 
After the update, even single-item arrays are having their string wrapped in <p> tags. In the case of a hollis_id note, we use this item in a link, and the tags which are now present break the link. Since removing the tags or reverting the change could have effects throughout the UI, I assume the best fix was to remove in the case that the note is used within the link.