### PR TITLE
remove inheritance of titles from collection inventory

### DIFF
--- a/public/views/shared/_idbadge.html.erb
+++ b/public/views/shared/_idbadge.html.erb
@@ -22,7 +22,9 @@ end
 
 <%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
   <% if !props.fetch(:full,false) %>
-    <a class="record-title" href="<%= app_prefix(result.uri) %>">  <%== result.display_string %></a>
+    <a class="record-title" href="<%= app_prefix(result.uri) %>">
+      <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+    </a>
   <% else %>
     <%== result.display_string %>
   <% end %>


### PR DESCRIPTION
Removes inheritance of series headings from Collection Inventory when child components do not have a title.

Backports code in 3.0.2 to plugin.