### PR TITLE
Note types in .notes are generally arrays of notes rather than single notes.

### DIFF
--- a/public/views/hvd_pdf/_archival_object.html.erb
+++ b/public/views/hvd_pdf/_archival_object.html.erb
@@ -1,68 +1,72 @@
 <%=  render(:partial => 'return_toc') if prev.to_i > level.to_i  %>
 
 <% (level - 1).times do |previous_level| %>
-<div class="print-record-border level-<%= previous_level + 1 %>">
+  <div class="print-record-border level-<%= previous_level + 1 %>">
 <% end %>
 
-  <div class="avoid-break">
-    <div class="print-record-border print-record level-<%= level %> <%= record.level %>">
-        <h3><a class="record-title" id="<%= record.uri %>"><%= record.display_string.gsub(/&(?!(\w{2,};))/, "&amp;").html_safe %></a></h3>
-	<% id = (record.direct_component_id.blank?)? '' : record.direct_component_id
-	   id << " #{container_string}"
-         %>
-        <div class="indented">
-	<% unless id.blank? %>
-	  <div><span class='label'><%= t('resource._public.finding_aid.identifier') %></span> <%= id %></div>
-	<% end %>
-        <% record.dates.each do |date| %>
-           <% next if date['_inherited'] %>
-              <div><span class='label'><%= I18n.t('resource._public.finding_aid.date') %></span> <%= date['final_expression'] %></div>
-        <% end %>
-        <% record.extents.each do |extent| %>
-            <% next if extent['_inherited'] %>
-              <div><span class='label'><%= I18n.t('resource._public.physdesc') %></span> <%= extent['display'] %></div>
-        <% end %>
-	<% if record.agents && Array(record.agents['creator']).length > 0 %>
-	   <% a_direct_creator = record.agents['creator'].reject{|r| r['_inherited']}.take(1) %>
-	   <% unless a_direct_creator.empty? %>
-	     <% a_direct_creator.each do |one| %>
-	       <div><span class='label'><%= I18n.t("enumerations.linked_agent_role.creator") %></span>
-	       <% agent = one.fetch('_resolved') %>
-	       <%= agent['title'] %> <% relator = (one['relator'].blank?) ? nil : t("enumerations.linked_agent_archival_record_relators.#{one['relator']}", :default => nil) %> <%= "( #{relator} )" unless relator.blank? %> 
-	       </div>
-	     <% end %>
-	   <% end %>
-	<% end %>
-	<% note = record.notes.dig('physdesc') %>
-	<% unless note.blank? || note['is_inherited'] %>
-              <div><span class='label'><%= I18n.t('resource._public.physdesc') %></span> <%== note['note_text'].gsub(/&(?!(\w{2,};))/, "&amp;") %></div>
-        <% end %>
-	<% unless urn.blank? %>
-	    <div><a href='<%= urn %>' target='frmpdf'><%= urn %></a></div>
-	<% end %>
+<div class="avoid-break">
+  <div class="print-record-border print-record level-<%= level %> <%= record.level %>">
+    <h3><a class="record-title" id="<%= record.uri %>"><%= record.display_string.gsub(/&(?!(\w{2,};))/, "&amp;").html_safe %></a></h3>
+	  <% id = (record.direct_component_id.blank?)? '' : record.direct_component_id
+	  id << " #{container_string}"
+    %>
+    <div class="indented">
+	    <% unless id.blank? %>
+	      <div><span class='label'><%= t('resource._public.finding_aid.identifier') %></span> <%= id %></div>
+	    <% end %>
+      <% record.dates.each do |date| %>
+        <% next if date['_inherited'] %>
+        <div><span class='label'><%= I18n.t('resource._public.finding_aid.date') %></span> <%= date['final_expression'] %></div>
+      <% end %>
+      <% record.extents.each do |extent| %>
+        <% next if extent['_inherited'] %>
+        <div><span class='label'><%= I18n.t('resource._public.physdesc') %></span> <%= extent['display'] %></div>
+      <% end %>
+	    <% if record.agents && Array(record.agents['creator']).length > 0 %>
+	      <% a_direct_creator = record.agents['creator'].reject{|r| r['_inherited']}.take(1) %>
+	      <% unless a_direct_creator.empty? %>
+	        <% a_direct_creator.each do |one| %>
+	          <div><span class='label'><%= I18n.t("enumerations.linked_agent_role.creator") %></span>
+	            <% agent = one.fetch('_resolved') %>
+	            <%= agent['title'] %> <% relator = (one['relator'].blank?) ? nil : t("enumerations.linked_agent_archival_record_relators.#{one['relator']}", :default => nil) %> <%= "( #{relator} )" unless relator.blank? %>
+	          </div>
+	        <% end %>
+	      <% end %>
+	    <% end %>
+	    <% note = ASUtils.wrap(record.notes.dig('physdesc')).first %>
+	    <% unless note.blank? || note['is_inherited'] %>
+        <div><span class='label'><%= I18n.t('resource._public.physdesc') %></span> <%== note['note_text'].gsub(/&(?!(\w{2,};))/, "&amp;") %></div>
+      <% end %>
+	    <% unless urn.blank? %>
+	      <div><a href='<%= urn %>' target='frmpdf'><%= urn %></a></div>
+	    <% end %>
 
-        <% record.notes.each do |note_type, note| %>
-           <% if note_type != 'physdesc' && !note['is_inherited'] %>
-<!-- can't use shared/single_note here, because of div issues -->
-              <%= render(:partial => 'arch_obj_note', :locals => { :note => note, :note_type => note_type}) %>
-            <% end %>
+      <% record.notes.each do |note_type, note| %>
+        <% notes = ASUtils.wrap(note) %>
+        <% notes.each do |note| %>
+          <% if note_type != 'physdesc' && !note['is_inherited'] %>
+            <!-- can't use shared/single_note here, because of div issues -->
+            <%= render(:partial => 'arch_obj_note', :locals => { :note => note, :note_type => note_type}) %>
+          <% end %>
         <% end %>
-        <% subjects = Array(record.subjects).reject {|s| s['is_inherited']} %>
-           <% if !subjects.empty? %>
-	    <dl>
-              <dt><%= I18n.t('pdf_reports.controlled_access_headings') %></dt>
-               <dd>
-                 <ul>
-                   <% subjects.each do |subject| %>
-                    <li><%= subject['title'] %></li>
-                   <% end %>
-                 </ul>
-               </dd>
-	     </dl>
-           <% end %>
-        </div>
+      <% end %>
+
+      <% subjects = Array(record.subjects).reject {|s| s['is_inherited']} %>
+      <% if !subjects.empty? %>
+	      <dl>
+          <dt><%= I18n.t('pdf_reports.controlled_access_headings') %></dt>
+          <dd>
+            <ul>
+              <% subjects.each do |subject| %>
+                <li><%= subject['title'] %></li>
+              <% end %>
+            </ul>
+          </dd>
+	      </dl>
+      <% end %>
     </div>
   </div>
-<% (level - 1).times do |previous_level| %>
 </div>
+<% (level - 1).times do |previous_level| %>
+  </div>
 <% end %>

--- a/public/views/hvd_pdf/_end_info.html.erb
+++ b/public/views/hvd_pdf/_end_info.html.erb
@@ -13,7 +13,7 @@
 <%= render(:partial => 'return_toc') %>
 <% end %>
 
-<% note = record.notes.dig('separatedmaterial') %>
+<% note = ASUtils.wrap(record.notes.dig('separatedmaterial')).first %>
 <% unless note.blank? %>
 <div>
    <a id="separatedmaterial"></a>

--- a/public/views/hvd_pdf/_resource.html.erb
+++ b/public/views/hvd_pdf/_resource.html.erb
@@ -26,7 +26,7 @@
         <dt><%= I18n.t('resource._public.physdesc') %></dt><dd><%= extent['display'] %></dd>
     <% end %>
 
-    <% note = record.notes.dig('physdesc') || '' %>
+    <% note = ASUtils.wrap(record.notes.dig('physdesc')).first || '' %>
     <% unless note.blank? %>
        <a id="note-physdesc"></a>
        <dt><%= I18n.t("enumerations._note_types.physdesc") %></dt><dd><%== note['note_text'].gsub(/&(?!(\w{2,};))/, "&amp;").html_safe %></dd>
@@ -37,7 +37,7 @@
     <% end %>
 
     <% %w(langmaterial abstract accessrestrict userestrict acqinfo processinfo relatedmaterial  prefercite).each do |type| %>
-       <% note = record.notes.dig(type) %>
+       <% note = ASUtils.wrap(record.notes.dig(type)).first %>
        <% if  type == 'processinfo'
 	    unless note.blank? || note['subnotes'].blank? || note['subnotes'].length < 2
 	      if (note['label']||'') != 'Processing Information'
@@ -54,14 +54,14 @@
 	       label = t("pdf_reports.alma")
 	    elsif label.blank?
 	       label =  t("enumerations._note_types.#{type}")
-	    else 
+	    else
 	       label = label.titlecase
 	    end %>
          <dt><%= label %></dt>
          <dd><%= render partial:  'shared/single_note', locals: {:type => type, :note_struct => note, :notitle => true, :pdf => true} %></dd>
-       <% end %>  
+       <% end %>
     <% end %>
-    
+
     <%= render(:partial => 'digital_object_links', :locals => {
         :instances => record.instances
     }) %>
@@ -91,16 +91,20 @@
 <% end %>
 
 <% record.notes.each do |note_type, note| %>
-    <% next if %w(langmaterial abstract accessrestrict userestrict acqinfo processinfo relatedmaterial separatedmaterial physdesc prefercite).include?(note_type) %>
+  <% next if %w(langmaterial abstract accessrestrict userestrict acqinfo processinfo relatedmaterial separatedmaterial physdesc prefercite).include?(note_type) %>
+
+  <% notes = ASUtils.wrap(note) %>
+  <% notes.each do |note| %>
     <a id="note-<%= note_type %>"></a>
     <h2><% if note['label'] %>
-            <%= note['label'].titlecase %>
-        <% else %>
-            <%= I18n.t("enumerations._note_types.#{note_type}") %>
-        <% end %> </h2>
+      <%= note['label'].titlecase %>
+    <% else %>
+      <%= I18n.t("enumerations._note_types.#{note_type}") %>
+    <% end %> </h2>
     <%= render partial: 'shared/single_note', locals: {:type => note_type, :note_struct => note, :notitle => true}   %>
 
     <%= render(:partial => 'return_toc') %>
+  <% end %>
 <% end %>
 
 

--- a/public/views/hvd_pdf/_toc.html.erb
+++ b/public/views/hvd_pdf/_toc.html.erb
@@ -15,8 +15,11 @@
 	<li class="level-1"><a href="#administrative-information"><%= I18n.t('pdf_reports.administrative_information') %></a></li>
 <% end %>
         <% resource.notes.each do |note_type, note| %>
-            <% next if %w(langmaterial separatedmaterial abstract accessrestrict userestrict acqinfo processinfo relatedmaterial prefercite).include?(note_type) %>
+          <% next if %w(langmaterial separatedmaterial abstract accessrestrict userestrict acqinfo processinfo relatedmaterial prefercite).include?(note_type) %>
+          <% notes = ASUtils.wrap(note) %>
+          <% notes.each do |note|  %>
             <li class="level-1"> <a href="#note-<%= note_type %>"><% if note['label'] %><%= note['label'].titlecase %><% else %><%= I18n.t("enumerations._note_types.#{note_type}") %> <% end %></a></li>
+          <% end %>
         <% end %>
 
 
@@ -29,7 +32,7 @@
 	<% unless resource.subjects.blank? %>
 	  <li class="level-1"><a href="#subjects"><%= I18n.t('pdf_reports.controlled_access_headings') %></a></li>
 	<% end %>
-	<% note = resource.notes.dig('separatedmaterial') %>
+	<% note = ASUtils.wrap(resource.notes.dig('separatedmaterial')).first %>
 	<% unless note.blank? %>
 	   <li class="level-1"><a href="#separatedmaterial"><% if note['label'] %><%= note['label'].titlecase %><% else %><%= I18n.t("enumerations._note_types.separatedmaterial") %> <% end %></a></li>
 	<% end %>


### PR DESCRIPTION
Due to assumptions about singularity of notes, PDF generation fails in cases where a type of notes can be plural.  This alters all note access in the plugin to support multiple returned notes.