### PR TITLE
Replace XMLCleaner usage with single-run regexp and SAX parsing

### DIFF
--- a/public/models/fixup_document.rb
+++ b/public/models/fixup_document.rb
@@ -1,0 +1,26 @@
+class FixupDocument < Nokogiri::XML::SAX::Document
+  attr_accessor :file
+  def initialize(file)
+    @file = file
+  end
+
+  def start_element_namespace(name, attrs=[], prefix=nil, uri=nil, ns=[])
+    @file << "<#{name}"
+    unless attrs.empty?
+      attrs.each do |attr|
+        @file << " #{attr.localname}=\"#{attr.value.sub('"', '\"')}\""
+      end
+    end
+    @file << '>'
+  end
+
+  def characters(chars)
+    chars.gsub!(/&(?!amp;)/, '&amp;')
+    @file << chars
+  end
+
+  def end_element_namespace(name, prefix= nil, uri=nil)
+    @file << '</' << name << '>'
+  end
+
+end

--- a/public/models/hvd_pdf.rb
+++ b/public/models/hvd_pdf.rb
@@ -1,6 +1,8 @@
 require 'tempfile'
 require 'fileutils'
 require 'pp'
+require_relative "fixup_document"
+
 class HvdPDF
 
   DEPTH_1_LEVELS = ['collection', 'recordgrp', 'series']
@@ -31,18 +33,22 @@ class HvdPDF
     filename.gsub(' ', '_') + '.pdf'
   end
 
+
   def short_title
     @short_title || suggested_filename
   end
 
+  def strip_xlink_prefix(html)
+    # Because the version of nokogiri in ASpace doesn't allow unbound namespaces in the sax parser
+    html.gsub!(/ xlink:(\S+)(?=\s*=)/, ' \1')
+    html
+  end
+
   def source_file
-    # We'll use the original controller so we can find and render the PDF
-    # partials, but just for its ERB rendering.
-#    renderer = PdfController.new
-     renderer = HvdPdfController.new
+    renderer = HvdPdfController.new
     start_time = Time.now
 
-    @repo_code = @resource.repository_information.fetch('top').fetch('repo_code')
+    @repo_code = @resource.repository_information.dig('top', 'repo_code')
 
     # .length == 1 would be just the resource itself.
     has_children = @ordered_records.entries.length > 1
@@ -57,27 +63,37 @@ class HvdPDF
         false
       end
     }
+
+    Rails.logger.debug("AOs filtered: #{Time.now - start_time} seconds elapsed")
     out_html = Tempfile.new
-    out_html.write(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource, :bottom => @last_level, :ordered_aos => toc_aos})
+    html_fixer = Nokogiri::XML::SAX::PushParser.new(FixupDocument.new(out_html))
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'header', layout: false, :locals => {:record => @resource, :bottom => @last_level, :ordered_aos => toc_aos}))
 
-    out_html.write(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource})
+    Rails.logger.debug("Header rendered: #{Time.now - start_time} seconds elapsed")
 
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'titlepage', layout: false, :locals => {:record => @resource}))
 
-    out_html.write(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos})
+    Rails.logger.debug("Titlepage rendered: #{Time.now - start_time} seconds elapsed")
 
-    out_html.write(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children})
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'toc', layout: false, :locals => {:resource => @resource, :has_children => has_children, :ordered_aos => toc_aos}))
 
+    Rails.logger.debug("TOC rendered: #{Time.now - start_time} seconds elapsed")
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'resource', layout: false, :locals => {:record => @resource, :has_children => has_children}))
+    Rails.logger.debug("Resource rendered: #{Time.now - start_time} seconds elapsed")
     page_size = 50
 
     previous_level = 1
-    
+
     @ordered_records.entries.drop(1).each_slice(page_size) do |entry_set|
+      Rails.logger.debug("Page start: #{Time.now - start_time} seconds elapsed")
       if AppConfig[:pui_pdf_timeout] && AppConfig[:pui_pdf_timeout] > 0 && (Time.now.to_i - start_time.to_i) >= AppConfig[:pui_pdf_timeout]
         raise TimeoutError.new("PDF generation timed out.  Sorry!")
       end
 
       uri_set = entry_set.map(&:uri).map {|s| s + "#pui"}
+      Rails.logger.debug("Record set get start: #{Time.now - start_time} seconds elapsed")
       record_set = archivesspace.search_and_sort_records(uri_set, {}, true).records
+      Rails.logger.debug("Record set get end: #{Time.now - start_time} seconds elapsed")
 
       record_set.zip(entry_set).each do |record, entry|
         next unless record.is_a?(ArchivalObject)
@@ -116,34 +132,32 @@ class HvdPDF
             end
           end
         end
-
+        Rails.logger.debug("Record set end: #{Time.now - start_time} seconds elapsed")
         container_string = container_array.join("; ")
-        
-        out_html.write(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth, :prev => previous_level, :urn => urn, :container_string => container_string})
+
+        html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'archival_object', layout: false, :locals => {:record => record, :level => entry.depth, :prev => previous_level, :urn => urn, :container_string => container_string}))
+        Rails.logger.debug("AO rendered: #{Time.now - start_time} seconds elapsed")
         previous_level = entry.depth
       end
+      Rails.logger.debug("Page rendered: #{Time.now - start_time} seconds elapsed")
     end
 
-    out_html.write(renderer.render_to_string partial: 'end_info', layout: false,  :locals => {:record => @resource})
-    out_html.write(renderer.render_to_string partial: 'footer', layout: false)
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'end_info', layout: false,  :locals => {:record => @resource}))
+    Rails.logger.debug("end_info rendered: #{Time.now - start_time} seconds elapsed")
+    html_fixer.write(strip_xlink_prefix(renderer.render_to_string partial: 'footer', layout: false))
+    Rails.logger.debug("footer rendered: #{Time.now - start_time} seconds elapsed")
+    html_fixer.finish
     out_html.close
 
     out_html
   end
 
   def generate
+    start_time = Time.now
+    Rails.logger.info("Starting generate at: #{Time.now}")
     out_html = source_file
-    begin
-      XMLCleaner.new.clean(out_html.path)
-    rescue Exception => bang
-      Rails.logger.error("Error during processing of /repositories/#{@repo_id}/resources/#{@resource_id}: #{$!}")
-      Rails.logger.error(bang.backtrace.pretty_inspect)
-      copy_file(out_html.path)
-      raise
-    end
 
-#Pry::ColorPrinter.pp "HTML file: #{out_html.path}"
-    
+    Rails.logger.info("source_file complete: #{Time.now - start_time} seconds elapsed")
     pdf_file = Tempfile.new
     pdf_file.close
     begin
@@ -159,6 +173,7 @@ class HvdPDF
       pdf_output_stream = java.io.FileOutputStream.new(pdf_file.path)
       renderer.create_pdf(pdf_output_stream)
       pdf_output_stream.close
+      Rails.logger.info("PDF created: #{Time.now - start_time} seconds elapsed")
     rescue Exception => bang
       Rails.logger.error("Error during processing of /repositories/#{@repo_id}/resources/#{@resource_id}: #{$!}")
       Rails.logger.error(bang.backtrace.join("\n\t").pretty_inspect)


### PR DESCRIPTION
Changes code that previously used the XMLCleaner
class (https://github.com/archivesspace/archivesspace/blob/4cda3fef3eab93f1c8886b191619e0023bc5a3b7/public/app/lib/xml_cleaner.rb)
to handle entities and namespace issues with a combination of regular
expressions and a Nokogiri::XML::SAX::PushParser.

Speed is still abysmal, but failures no longer wedge the system by
running 10,000 times when they encounter any error other than
namespace or entities other than ampersand, they fail in a reasonable time.