### PR TITLE
Ltsmaint323 non latin character new java stuff

### DIFF
--- a/public/models/hvd_pdf.rb
+++ b/public/models/hvd_pdf.rb
@@ -159,16 +159,45 @@ class HvdPDF
     pdf_file.close
     begin
 
-      renderer = org.xhtmlrenderer.pdf.ITextRenderer.new
-      renderer.set_document(java.io.File.new(out_html.path))
+      # renderer = org.xhtmlrenderer.pdf.ITextRenderer.new
+      # font_resolver = renderer.get_font_resolver()
+      split_path = Rails.root.to_s.split('/')
+      fonts_path = split_path[0..split_path.rindex('archivesspace')].join('/') + "/stylesheets/fonts/*.ttf"
 
-    # FIXME: We'll need to test this with a reverse proxy in front of it.
-      renderer.shared_context.base_url = base_url
+      builder = com.openhtmltopdf.pdfboxout.PdfRendererBuilder.new
 
-      renderer.layout
 
+      Dir[fonts_path].each do |file|
+        builder.use_font(java.io.File.new(file), File.basename(file)[/.*(?=.ttf$)/])
+      end
+
+      # renderer.set_document(java.io.File.new(out_html.path))
+
+      # FIXME: We'll need to test this with a reverse proxy in front of it.
+      # renderer.shared_context.base_url = base_url
+
+      # renderer.layout
+
+      Rails.logger.error('1')
       pdf_output_stream = java.io.FileOutputStream.new(pdf_file.path)
-      renderer.create_pdf(pdf_output_stream)
+      Rails.logger.error('2')
+      Rails.logger.error(out_html.path)
+      builder.with_file(java.io.File.new(out_html.path))
+      Rails.logger.error('3')
+      builder.to_stream(pdf_output_stream)
+      Rails.logger.error('4')
+      builder.run
+7
+      # Rails.logger.error('3')
+      # builder.to_stream(pdf_output_stream)
+      # Rails.logger.error('4')
+      # # builder.with_file(out_html)
+      # builder.withW3cDocument(org.jsoup.helper.W3CDom.new.fromJsoup(doc), baseUri);
+      # Rails.logger.error('5')
+      # builder.run
+      # Rails.logger.error('6')
+
+      # renderer.create_pdf(pdf_output_stream)
       pdf_output_stream.close
       Rails.logger.info("PDF created: #{Time.now - start_time} seconds elapsed")
     rescue Exception => bang

--- a/public/views/hvd_pdf/_header.html.erb
+++ b/public/views/hvd_pdf/_header.html.erb
@@ -3,10 +3,11 @@
         <meta charset="utf-8" />
 
         <style>
- html {
-   font-family: sans-serif;
-   font-size: 12px;
-}
+
+         html {
+           font-family: "KurintoText-Rg", "KurintoTextJP-Rg", "KurintoTextSC-Rg", "KurintoTextKR-Rg", sans-serif;
+           font-size: 12px;
+         }
 
  .title-page {
      page-break-after: always;
@@ -68,7 +69,7 @@
     margin-top: .75em;
     font-weight: bold;
  }
- 
+
  .indented { margin-left: 1em; font-size: 0.9em; }
  .indented h4 {font-weight: bold; font-size: 0.9em; }
  dl {
@@ -154,7 +155,7 @@
 
  .print-record-border.level-1 { margin-left: 1em; }
 /* .print-record-border.level-2 { margin-left: 1em }
- .print-record-border.level-3 { margin-left: 1em; }  
+ .print-record-border.level-3 { margin-left: 1em; }
  .print-record-border.level-4 { margin-left: .25em; }
  .print-record-border.level-5 { margin-left: .25em; }
  .print-record-border.level-6 { margin-left: .25em; }
@@ -256,4 +257,3 @@
         </style>
     </head>
     <body>
-


### PR DESCRIPTION
Replaces existing PDF library with one that supports fallback fonts (note that OpenHTMLtoPDF and all dependency jars must be added to /archivesspace/lib directory at runtime to support this)