### PR TITLE
Fix the houghton link for Ask a Librarian

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -118,7 +118,7 @@ Appointments are available Monday – Friday between 9:30am-12pm and 1pm-4:30pm.
       bak: https://asklib.sc.hbs.org/index.php?
       med: https://www.countway.harvard.edu/content/ask-us
       law: https://asklib.law.harvard.edu/HSC/index
-      hou: https://ask.library.harvard.edu/friendly.php?slug=houghton
+      hou: https://ask.library.harvard.edu/houghton
   repos:
     ajp:
       lead_graph: "<p>The Arnold Arboretum Horticultural Library is a specialized collection devoted to the study of temperate woody plants. We collect works on botany, horticulture, floras, urban forestry and taxonomy. The library contains more than 25,000 volumes and 40,000 photographs, and includes an archive that both documents the Arboretum's history and is a repository for 19th, 20th, and 21st century horticultural and botanical collections.</p>"


### PR DESCRIPTION
To test:

Pull this branch of the plug-in and spin up locally. Navigate to a Houghton finding aid and click the 'Ask a Librarian' button/link and you will be taken to the Houghton page instead of the broken 404.