### PR TITLE
Add new GTM tracking id to run concurrently with other analytics code

### DIFF
--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -18,5 +18,13 @@ gtag('js', new Date());
 gtag('config', 'UA-52592218-14');
 </script>
 
+<!-- Google Tag Manager NEW WITH GA4 -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WSHSDQ5');</script>
+<!-- End Google Tag Manager -->
+
 <%= javascript_include_tag "#{@base_url}/assets/harvard.js" %>
 <%= javascript_include_tag "#{@base_url}/assets/infinite_scroll_replacement.js" %>

--- a/public/views/shared/_header.html.erb
+++ b/public/views/shared/_header.html.erb
@@ -1,3 +1,8 @@
+<!-- Google Tag Manager (noscript) NEW WITH GA4 -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WSHSDQ5"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
 <section  id="header">
   <div class="container logo-container">
     <div class="row" id="logo">


### PR DESCRIPTION
**Add new GTM tracking id to run concurrently with other analytics code**
* * *

# What does this Pull Request do?
Adds the analytics we are using to reference the new tracking id that is being applied across library systems. 
Old tracking id and code will remain in place.

# How should this be tested?
* Spin up local environment
* Inspect code to see that the new id (GTM-WSHSDQ5) and code are in the correct places:
   * `<script>` tag should be in the `<head>`
   * `<noscript>` tag should be in the `<body>`
   * Old analytics code referencing the tracking id UA-52592218-14 should also be present in the `<head>` region
* Test in preview mode using tagmanager.google.com ([video ](https://drive.google.com/file/d/1wB3iJphfdrj28KLRgw456cnKeMNcqKb2/view?usp=sharing)for how you can check this locally *works best to test in Chrome)
* Once in production, we can test again to confirm that it's firing correctly on both the Google Tag Manager and Google Analytics side of things

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? NA
- integration tests? NA

# Interested parties
@phil-plencner-hl @enriquediaz