### PR TITLE
Use config to decide if accordian is expanded or not by default

### DIFF
--- a/public/views/shared/_record_innards.html.erb
+++ b/public/views/shared/_record_innards.html.erb
@@ -128,5 +128,5 @@
         <%= render :file => template if File.exists?(template) %>
       <% end %>
     </div>
-    <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
+    <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>", <%= AppConfig[:pui_expand_all] %>);
     </script>


### PR DESCRIPTION
Brings in new functionality from core to decide on this behavior.